### PR TITLE
chore: run the action using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'Output Actions instead of applying them'
     default: false
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
The action was declared to use node12. Such version has been deprecated for a long time. Running the action generated 2 warnings and in pratice, the GitHub runner already runs it with node20.

```
The following actions uses node12 which is deprecated and will be forced to run on node16: adrianjost/actions-surge.sh-teardown@v1.0.3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
teardown_inactive_deployement
The following actions uses Node.js version which is deprecated and will be forced to run on node20: adrianjost/actions-surge.sh-teardown@v1.0.3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```