### PR TITLE
docs: remove build ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An GitHub Action to TearDown surge.sh projects that match a regex
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-[![Build](https://github.com/adrianjost/actions-surge.sh-teardown/workflows/Build/badge.svg)](https://github.com/adrianjost/actions-surge.sh-teardown/actions?query=workflow%3ABuild) [![Release](https://github.com/adrianjost/actions-surge.sh-teardown/workflows/Release/badge.svg)](https://github.com/adrianjost/actions-surge.sh-teardown/actions?query=workflow%3ARelease)
+[![Release](https://github.com/adrianjost/actions-surge.sh-teardown/workflows/Release/badge.svg)](https://github.com/adrianjost/actions-surge.sh-teardown/actions?query=workflow%3ARelease)
 
 ## Inputs
 


### PR DESCRIPTION
The GitHub Action is no longer executed on main, to reduce actions usage.